### PR TITLE
Add M5Paper S3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Originally forked from [https://github.com/Bastelschlumpf/M5PaperWeather](https:
 
 ## M5PaperWeather
 My takes on that great project thanks to the original forks of forks, see above.
-- The librairies has been upgraded.
+- The libraries have been upgraded.
+- Added experimental support for **M5Paper S3** using `M5Unified` and `M5GFX`.
 - I’ve added two view and kept the two forked views and it’s simple two swap between them. Simply uncomment/comment the declaration inside the lines 28 to 31 in main.cpp
 - pio run -t upload
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,9 +8,9 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:m5stack-paper]
+[env:m5paper-s3]
 platform = espressif32
-board = m5stack-fire
+board = m5stack-cores3
 framework = arduino
 monitor_speed = 115200
 upload_speed = 230400
@@ -21,7 +21,8 @@ upload_speed = 230400
 ;    --auth=d0i22BqfLkm5
 
 lib_deps =
-	m5stack/M5EPD@^0.1.5
-	bblanchon/ArduinoJson@7.1
-	paulstoffregen/Time@^1.6.1
-	signetica/MoonRise@^2.0.4
+        m5stack/M5Unified
+        m5stack/M5GFX
+        bblanchon/ArduinoJson@7.1
+        paulstoffregen/Time@^1.6.1
+        signetica/MoonRise@^2.0.4

--- a/src/Display.hpp
+++ b/src/Display.hpp
@@ -24,7 +24,7 @@
 #include "Icons.hpp"
 
 
-M5EPD_Canvas canvas(&M5.EPD); // Main canvas of the e-paper
+M5EPD_Canvas canvas(&M5_EPD); // Main canvas of the e-paper
 
 /* Main class for drawing the content to the e-paper display. */
 class WeatherDisplay

--- a/src/Display_Bastelschlumpf.hpp
+++ b/src/Display_Bastelschlumpf.hpp
@@ -24,7 +24,7 @@
 #include "Icons.hpp"
 
 
-M5EPD_Canvas canvas(&M5.EPD); // Main canvas of the e-paper
+M5EPD_Canvas canvas(&M5_EPD); // Main canvas of the e-paper
 
 /* Main class for drawing the content to the e-paper display. */
 class WeatherDisplay

--- a/src/Display_Engineer.hpp
+++ b/src/Display_Engineer.hpp
@@ -24,7 +24,7 @@
 #include "Icons.hpp"
 
 
-M5EPD_Canvas canvas(&M5.EPD); // Main canvas of the e-paper
+M5EPD_Canvas canvas(&M5_EPD); // Main canvas of the e-paper
 
 /* Main class for drawing the content to the e-paper display. */
 class WeatherDisplay

--- a/src/Display_Minimalist.hpp
+++ b/src/Display_Minimalist.hpp
@@ -24,7 +24,7 @@
 #include "Icons.hpp"
 
 
-M5EPD_Canvas canvas(&M5.EPD); // Main canvas of the e-paper
+M5EPD_Canvas canvas(&M5_EPD); // Main canvas of the e-paper
 
 /* Main class for drawing the content to the e-paper display. */
 class WeatherDisplay
@@ -115,7 +115,7 @@ void WeatherDisplay::Show()
     canvas.setTextDatum(MC_DATUM);
         DrawBattery();
         DrawWeatherInfo();
-    M5.EPD.SetColorReverse(true);
+    M5_EPD.SetColorReverse(true);
     canvas.pushCanvas(0, 0, UPDATE_MODE_GC16);
     delay(500);
 }

--- a/src/Display_mzyy94.hpp
+++ b/src/Display_mzyy94.hpp
@@ -24,7 +24,7 @@
 #include "Icons.hpp"
 
 
-M5EPD_Canvas canvas(&M5.EPD); // Main canvas of the e-paper
+M5EPD_Canvas canvas(&M5_EPD); // Main canvas of the e-paper
 
 /* Main class for drawing the content to the e-paper display. */
 class WeatherDisplay

--- a/src/M5Compatibility.hpp
+++ b/src/M5Compatibility.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#if __has_include(<M5Unified.h>)
+#include <M5Unified.h>
+#include <M5GFX.h>
+#define USE_M5UNIFIED
+using M5Display = M5GFX;
+
+class M5EPD_Canvas : public M5Canvas {
+public:
+    enum grayscale_t {
+        G0 = 0, G1, G2, G3, G4, G5, G6, G7,
+        G8, G9, G10, G11, G12, G13, G14, G15
+    };
+    M5EPD_Canvas(M5Display* dp = &M5.Display) : M5Canvas(dp) {}
+};
+
+#define M5_EPD M5.Display
+#else
+#include <M5EPD.h>
+#define M5_EPD M5.EPD
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@
   * Main file with setup() and loop()
   */
 
-#include <M5EPD.h>
+#include "M5Compatibility.hpp"
 #include "Config.hpp"
 //#include "ConfigOverride.hpp" // Remove this line
 #include "Data.hpp"


### PR DESCRIPTION
## Summary
- add compatibility layer for M5Unified/M5GFX
- update EPD helper for ESP32‑S3
- adapt display code to use compatibility macros
- adjust PlatformIO config for the new board
- mention S3 support in README

## Testing
- `pio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6859dbe00b4c832cbec88c69ced11a8a